### PR TITLE
Enabling other editions of msvc

### DIFF
--- a/hello.c
+++ b/hello.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 
-
 int main(int argc, char **argv)
 {
 	printf("Hello, world!\n");

--- a/hello.c
+++ b/hello.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 
+
 int main(int argc, char **argv)
 {
 	printf("Hello, world!\n");

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ const os = require('os')
 const path = require('path')
 const process = require('process')
 
-const EDITIONS = ['Community', 'Professional', 'Enterprise']
-const VERSIONS = ['2017', '2019']
+const EDITIONS = ['Enterprise', 'Professional', 'Community']
+const VERSIONS = ['2019', '2017']
 
 const InterestingVariables = [
     'INCLUDE',
@@ -32,10 +32,13 @@ async function main() {
     //     C2017: 'path\to\2017\Entreprise...',
     //     etc...
     // }
+    // Given the order of each list it should check
+    // for the more recent versions first and the
+    // highest grade edition first.
     var search_map = {}
 
-    EDITIONS.forEach(ed => {
-        VERSIONS.forEach(ver => {
+    VERSIONS.forEach(ver => {
+        EDITIONS.forEach(ed => {
             let prop = ed.charAt(0) + ver
             let path = `%ProgramFiles(x86)%\\Microsoft Visual Studio\\${ver}\\${ed}\\VC\\Auxiliary\\Build\\vcvarsall.bat`
 

--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ async function main() {
         return
     }
 
-    // this should generate an object like
-    // {
-    //     P2017: 'path\to\2017\Professional...',
-    //     C2017: 'path\to\2017\Entreprise...',
+    // this should generate an array like
+    // [
+    //     ['P2017', 'path\to\2017\Professional...'],
+    //     ['C2017', 'path\to\2017\Entreprise...'],
     //     etc...
-    // }
+    // [
     // Given the order of each list it should check
     // for the more recent versions first and the
     // highest grade edition first.
@@ -92,7 +92,6 @@ async function main() {
                @IF ERRORLEVEL 1 EXIT\n
                @SET`
 
-    console.log(script)
     core.debug(script)
 
     core.debug(`Writing helper file: ${helper}`)

--- a/index.js
+++ b/index.js
@@ -35,14 +35,14 @@ async function main() {
     // Given the order of each list it should check
     // for the more recent versions first and the
     // highest grade edition first.
-    var search_map = {}
+    var search_map = []
 
     VERSIONS.forEach(ver => {
         EDITIONS.forEach(ed => {
-            let prop = ed.charAt(0) + ver
+            let label = ed.charAt(0) + ver
             let path = `%ProgramFiles(x86)%\\Microsoft Visual Studio\\${ver}\\${ed}\\VC\\Auxiliary\\Build\\vcvarsall.bat`
 
-            search_map[prop] = path
+            search_map.push([label, path])
         })
     })
 
@@ -75,18 +75,18 @@ async function main() {
 
     var script = '';
 
-    for(let key in search_map) {
-        script += `@IF EXIST "${search_map[key]}" GOTO :${key}\n`
-    }
+    search_map.forEach(pair => {
+        script += `@IF EXIST "${pair[1]}" GOTO :${pair[0]}\n`
+    })
 
     script += `@ECHO "Microsoft Visual Studio not found"\n
                @EXIT 1\n`
 
-    for(let key in search_map) {
-        script += `:${key}\n
-                   @CALL "${search_map[key]}" ${args.join(' ')}\n
+    search_map.forEach(pair => {
+        script += `:${pair[0]}\n
+                   @CALL "${pair[1]}" ${args.join(' ')}\n
                    @GOTO ENV\n`
-    }
+    })
 
     script += `:ENV\n
                @IF ERRORLEVEL 1 EXIT\n

--- a/index.js
+++ b/index.js
@@ -34,14 +34,16 @@ async function main() {
     // }
     var search_map = {}
 
-    for(let ed in EDITIONS) {
-        for(let ver in VERSIONS) {
-            let prop = ed[0] + ver
+    EDITIONS.forEach(ed => {
+        VERSIONS.forEach(ver => {
+            let prop = ed.charAt(0) + ver
             let path = `%ProgramFiles(x86)%\\Microsoft Visual Studio\\${ver}\\${ed}\\VC\\Auxiliary\\Build\\vcvarsall.bat`
 
-            Object.defineProperty(search_map, prop, path)
-        }
-    }
+            search_map[prop] = path
+        })
+    })
+
+    core.debug(search_map)
 
     const arch    = core.getInput('arch')
     const sdk     = core.getInput('sdk')
@@ -89,6 +91,9 @@ async function main() {
                @IF ERRORLEVEL 1 EXIT\n
                @SET`
 
+    console.log(script)
+    core.debug(script)
+
     core.debug(`Writing helper file: ${helper}`)
     await fs.writeFile(helper, script)
 
@@ -120,4 +125,4 @@ async function main() {
     core.info(`Configured Developer Command Prompt`)
 }
 
-main().catch(() => core.setFailed('Could not setup Developer Command Prompt'))
+main().catch((e) => core.setFailed('Could not setup Developer Command Prompt: ' + e.message))

--- a/index.js
+++ b/index.js
@@ -43,8 +43,6 @@ async function main() {
         })
     })
 
-    core.debug(search_map)
-
     const arch    = core.getInput('arch')
     const sdk     = core.getInput('sdk')
     const toolset = core.getInput('toolset')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msvc-dev-cmd",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I'll probably use self hosted runners in a project and the Community version of Visual Studio will be installed on those. This enable your script to check for Community and Professional editions in addition to the Entreprise one offered by github.

The modification generate a kinda search map ordered by version then by edition. It generate the batch script that runs vcvarsall.bat on the fly given that search map.