### PR TITLE
Look for vcbuildtools.bat of VS 2015 as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ function findVcvarsall() {
             }
         }
     }
+    // Special case for Visual Studio 2015 (and maybe earlier), try it out too.
+    const path = `${programFiles}\\Microsoft Visual C++ Build Tools\\vcbuildtools.bat`
+    if (fs.existsSync(path)) {
+        return path
+    }
     throw new Error('Microsoft Visual Studio not found')
 }
 


### PR DESCRIPTION
“Visual C++” has its build tool batch files in a different place. Let's look there as well if we have not found 2017 or 2019 stuff.

Thanks to ReactOS project for figuring this out.

I'm not readily able to verify that it actually works, but let's try it out.