### PR TITLE
Architecture aliases: Win32 & Win64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,20 @@ jobs:
         uses: actions/checkout@v2
       - run: npm install
       - run: npm audit --audit-level=moderate
+  alias-arch:
+    name: arch aliases
+    runs-on: windows-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+      - name: Download Internet
+        run: npm install
+      - name: Enable Developer Command Prompt
+        uses: ./
+        with:
+          arch: Win32
+      - name: Compile and run some C code
+        shell: cmd
+        run: |
+          cl.exe hello.c
+          hello.exe

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Supports Windows. Does nothing on Linux and macOS.
 ## Inputs
 
 - `arch` – target architecture
-  - native compilation: `x86`, `x64` (default), `amd64` (synonym for x64)
+  - native compilation:
+    - `x64` (default) or its synonyms: `amd64`, `win64`
+    - `x86` or its synonyms: `win32`
   - cross-compilation: `x86_amd64`, `x86_arm`, `x86_arm64`,
   	`amd64_x86`, `amd64_arm`, `amd64_arm64`
 - `sdk` – Windows SDK to use

--- a/index.js
+++ b/index.js
@@ -77,11 +77,22 @@ function main() {
     // Add standard location of "vswhere" to PATH, in case it's not there.
     process.env.PATH += path.delimiter + VSWHERE_PATH
 
-    const arch    = core.getInput('arch')
+    var   arch    = core.getInput('arch')
     const sdk     = core.getInput('sdk')
     const toolset = core.getInput('toolset')
     const uwp     = core.getInput('uwp')
     const spectre = core.getInput('spectre')
+
+    // There are all sorts of way the architectures are called. In addition to
+    // values supported by Microsoft Visual C++, recognize some common aliases.
+    let arch_aliases = {
+        "win32": "x86",
+        "win64": "x64",
+    }
+    // Ignore case when matching as that's what humans expect.
+    if (arch.toLowerCase() in arch_aliases) {
+        arch = arch_aliases[arch.toLowerCase()]
+    }
 
     // Due to the way Microsoft Visual C++ is configured, we have to resort to the following hack:
     // Call the configuration batch file and then output *all* the environment variables.


### PR DESCRIPTION
By a public request, let's support aliases for architecture parameters. Treat `arch: Win32` as `x86` and `Win64` as `x64`.

Test this on CI just in case x86 breaks or something.