### PR TITLE
Export UCRTVersion and UniversalCRTSdkDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ const InterestingVariables = [
     'Path',
     'Platform',
     'VisualStudioVersion',
+    'UCRTVersion',
+    'UniversalCRTSdkDir',
     /^VCTools/,
     /^VSCMD_/,
     /^WindowsSDK/i,


### PR DESCRIPTION
These are required to build some components from the Swift toolchain (see https://github.com/actions/virtual-environments/issues/1652#issuecomment-729952649). Would be great if they could be exported.