### PR TITLE
Autodetect variables to export

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ function main() {
     // Now look at the new environment and export everything that changed.
     // These are the variables set by vsvars.bat. Also export everything
     // that was not there during the first sweep: those are new variables.
+    core.startGroup('Environment variables')
     for (let string of new_environment) {
         // vsvars.bat likes to print some fluff at the beginning.
         // Skip lines that don't look like environment variables.
@@ -146,6 +147,7 @@ function main() {
             core.exportVariable(name, new_value)
         }
     }
+    core.endGroup()
 
     core.info(`Configured Developer Command Prompt`)
 }

--- a/index.js
+++ b/index.js
@@ -11,21 +11,6 @@ const VERSIONS = ['2019', '2017']
 
 const VSWHERE_PATH = `${PROGRAM_FILES_X86}\\Microsoft Visual Studio\\Installer`
 
-const InterestingVariables = [
-    'INCLUDE',
-    'LIB',
-    'LIBPATH',
-    'VCINSTALLDIR',
-    'Path',
-    'Platform',
-    'VisualStudioVersion',
-    'UCRTVersion',
-    'UniversalCRTSdkDir',
-    /^VCTools/,
-    /^VSCMD_/,
-    /^WindowsSDK/i,
-]
-
 function findWithVswhere(pattern) {
     try {
         let installationPath = child_process.execSync(`vswhere -products * -latest -prerelease -property installationPath`).toString().trim()
@@ -113,15 +98,17 @@ function main() {
         args.push('-vcvars_spectre_libs=spectre')
     }
 
-    const command = `"${findVcvarsall()}" ${args.join(' ')} && set`
-    core.debug(`Running: ${command}`)
-    const environment = child_process.execSync(command, {shell: "cmd"}).toString().split('\r\n')
+    const vcvars = `"${findVcvarsall()}" ${args.join(' ')}`
+    core.debug(`vcvars command-line: ${vcvars}`)
+
+    const old_environment = child_process.execSync(`set`, {shell: "cmd"}).toString().split('\r\n')
+    const new_environment = child_process.execSync(`${vcvars} && set`, {shell: "cmd"}).toString().split('\r\n')
 
     // If vsvars.bat is given an incorrect command line, it will print out
     // an error and *still* exit successfully. Parse out errors from output
     // which don't look like environment variables, and fail if appropriate.
     var failed = false
-    for (let line of environment) {
+    for (let line of new_environment) {
         if (line.match(/^\[ERROR.*\]/)) {
             failed = true
             // Don't print this particular line which will be confusing in output.
@@ -135,13 +122,28 @@ function main() {
         throw new Error('invalid parameters')
     }
 
-    for (let string of environment) {
+    // Convert old environment lines into a dictionary for easier lookup.
+    let old_env_vars = {}
+    for (let string of old_environment) {
         const [name, value] = string.split('=')
-        for (let pattern of InterestingVariables) {
-            if (name.match(pattern)) {
-                core.exportVariable(name, value)
-                break
-            }
+        old_env_vars[name] = value
+    }
+
+    // Now look at the new environment and export everything that changed.
+    // These are the variables set by vsvars.bat. Also export everything
+    // that was not there during the first sweep: those are new variables.
+    for (let string of new_environment) {
+        // vsvars.bat likes to print some fluff at the beginning.
+        // Skip lines that don't look like environment variables.
+        if (!string.includes('=')) {
+            continue;
+        }
+        const [name, new_value] = string.split('=')
+        const old_value = old_env_vars[name]
+        // For new variables "old_value === undefined".
+        if (new_value !== old_value) {
+            core.info(`Setting ${name}`)
+            core.exportVariable(name, new_value)
         }
     }
 


### PR DESCRIPTION
Instead of using a hardcoded list of variables to export, use a more smart approach: first inspect the original environment, then look what variables have changed as a result of `vcvarsall.bat` invocation, and export all those new values.

Also, log the variables we export to be more debugging-friendly.

<details>
<summary>
This is how the output currently looks like.
</summary>

```
Found with vswhere: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat
Setting CommandPromptType
Setting DevEnvDir
Setting ExtensionSdkDir
Setting Framework40Version
Setting FrameworkDir
Setting FrameworkDIR64
Setting FrameworkVersion
Setting FrameworkVersion64
Setting FSHARPINSTALLDIR
Setting HTMLHelpDir
Setting INCLUDE
Setting LIB
Setting LIBPATH
Setting NETFXSDKDir
Setting Path
Setting Platform
Setting UCRTVersion
Setting UniversalCRTSdkDir
Setting VCIDEInstallDir
Setting VCINSTALLDIR
Setting VCToolsInstallDir
Setting VCToolsRedistDir
Setting VCToolsVersion
Setting VisualStudioVersion
Setting VS160COMNTOOLS
Setting VSCMD_ARG_app_plat
Setting VSCMD_ARG_HOST_ARCH
Setting VSCMD_ARG_TGT_ARCH
Setting VSCMD_VER
Setting VSINSTALLDIR
Setting VSSDK150INSTALL
Setting VSSDKINSTALL
Setting WindowsLibPath
Setting WindowsSdkBinPath
Setting WindowsSdkDir
Setting WindowsSDKLibVersion
Setting WindowsSdkVerBinPath
Setting WindowsSDKVersion
Setting WindowsSDK_ExecutablePath_x64
Setting WindowsSDK_ExecutablePath_x86
Setting __devinit_path
Setting __DOTNET_ADD_64BIT
Setting __DOTNET_PREFERRED_BITNESS
Setting __VSCMD_PREINIT_PATH
Setting __VSCMD_script_err_count
Configured Developer Command Prompt
```

</details>