### PR TITLE
Allow repeated invocation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,42 @@ jobs:
         uses: actions/checkout@v2
       - name: Download Internet
         run: npm install
-      - name: Enable Developer Command Prompt
+      - name: Enable Developer Command Prompt (amd64)
         uses: ./
-      - name: Compile and run some C code
+        with:
+          arch: amd64
+      - name: Compile and run some C code (amd64)
         shell: cmd
         run: |
           cl.exe hello.c
           hello.exe
+      - name: Enable Developer Command Prompt (amd64_x86)
+        uses: ./
+        with:
+          arch: amd64_x86
+      - name: Compile and run some C code (x86)
+        shell: cmd
+        run: |
+          cl.exe hello.c
+          hello.exe
+      - name: Enable Developer Command Prompt (amd64_arm)
+        uses: ./
+        with:
+          arch: amd64_arm
+      - name: Compile some C code (arm)
+        shell: cmd
+        run: |
+          cl.exe hello.c
+          dumpbin /headers hello.exe
+      - name: Enable Developer Command Prompt (amd64_arm64)
+        uses: ./
+        with:
+          arch: amd64_arm64
+      - name: Compile some C code (arm64)
+        shell: cmd
+        run: |
+          cl.exe hello.c
+          dumpbin /headers hello.exe
   audit:
     name: npm audit
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -87,6 +87,48 @@ If you experience compilation errors where `link` complains about unreasonable c
 Recommended workaround is to remove `/usr/bin/link` if that interferes with your builds.
 If this is not acceptable, please file an issue, then we'll figure out something better.
 
+### Reconfiguration
+
+You can invoke `ilammy/msvc-dev-cmd` multiple times during your jobs with different inputs
+to reconfigure the environment for building with different settings
+(e.g., to target multiple architectures).
+
+```yaml
+jobs:
+  release:
+    steps:
+      # ...
+      - name: Configure build for amd64
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+
+      - run: build # (for amd64)
+
+      - name: Configure build for x86
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_x86
+
+      - run: build # (for x86)
+
+      - name: Configure build for ARM64
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_arm64
+
+      - run: build # (for ARM64)
+
+      # ...
+```
+
+This mostly works but it's not really recommended
+since Developer Command Prompt was not meant for recursive reconfiguration.
+That said, if it does not work for you, please file an issue.
+
+Consider using [`strategy.matrix`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)
+to execute different build configuration in parallel, independent environments.
+
 ## License
 
 MIT, see [LICENSE](LICENSE).


### PR DESCRIPTION
As noted in the comment, repeated invocations of this action might have caused environment variables to overflow. This cute hack avoid this, allowing to reconfigure environment.

Resolves: https://github.com/ilammy/msvc-dev-cmd/issues/8#issuecomment-655898528