### PR TITLE
Print the error message from the environment configuration scripts at once

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,19 +122,17 @@ function main() {
     // If vsvars.bat is given an incorrect command line, it will print out
     // an error and *still* exit successfully. Parse out errors from output
     // which don't look like environment variables, and fail if appropriate.
-    var failed = false
-    for (let line of new_environment) {
+    const error_messages = new_environment.filter((line) => {
         if (line.match(/^\[ERROR.*\]/)) {
-            failed = true
             // Don't print this particular line which will be confusing in output.
-            if (line.match(/Error in script usage. The correct usage is:$/)) {
-                continue
+            if (!line.match(/Error in script usage. The correct usage is:$/)) {
+                return true
             }
-            core.error(line)
         }
-    }
-    if (failed) {
-        throw new Error('invalid parameters')
+        return false
+    })
+    if (error_messages.length > 0) {
+        throw new Error('invalid parameters' + '\r\n' + error_messages.join('\r\n'))
     }
 
     // Convert old environment lines into a dictionary for easier lookup.


### PR DESCRIPTION
Here are two examples to show the difference before and after this change.

<details>
<summary>Example 1</summary>

## Parameters

- sdk: A
- arch: x64

## Comparison of GHA summary

### Before

> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:vcvarsall.bat] Invalid argument found : A
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; Could not setup Developer Command Prompt: invalid parameters
> 
> ---
> 

### After

> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; Could not setup Developer Command Prompt: invalid parameters [ERROR:vcvarsall.bat] Invalid argument found : A
> 
> ---
> 

## Comparison of GHA log

### Before

```
...
Error: [ERROR:vcvarsall.bat] Invalid argument found : A
Error: Could not setup Developer Command Prompt: invalid parameters
...
```

### After

```
...
Error: Could not setup Developer Command Prompt: invalid parameters
[ERROR:vcvarsall.bat] Invalid argument found : A
...
```

</details>

<details>
<summary>Example 2</summary>

## Parameters

- sdk: 10.0.10240.0
- arch: x64

## Comparison of GHA summary

### Before

> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:winsdk.bat] Windows SDK 10.0.10240.0 : 'C:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\um' not found or was incomplete
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] *** VsDevCmd.bat encountered errors. Environment may be incomplete and/or incorrect. ***
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] In an uninitialized command prompt, please 'set VSCMD_DEBUG=[value]' and then re-run
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] vsdevcmd.bat [args] for additional details.
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] Where [value] is:
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] 1 : basic debug logging
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] 2 : detailed debug logging
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] 3 : trace level logging. Redirection of output to a file when using this level is recommended.
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] Example: set VSCMD_DEBUG=3
> 
> ---
> 
> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] vsdevcmd.bat > vsdevcmd.trace.txt 2>&1
> 
> ---
> 

As you can see, they are too much. And I have no idea why "Could not setup Developer Command Prompt: invalid parameters" is not here.

### After

> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; Could not setup Developer Command Prompt: invalid parameters [ERROR:winsdk.bat] Windows SDK 10.0.10240.0 : 'C:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\um' not found or was incomplete [ERROR...
> 
> &nbsp;&nbsp;&nbsp;&nbsp; show more
> 
> ---
> 

> (X) <job_name>
> &nbsp;&nbsp;&nbsp;&nbsp; Could not setup Developer Command Prompt: invalid parameters
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:winsdk.bat] Windows SDK 10.0.10240.0 : 'C:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\um' not found or was incomplete
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] *** VsDevCmd.bat encountered errors. Environment may be incomplete and/or incorrect. ***
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] In an uninitialized command prompt, please 'set VSCMD_DEBUG=[value]' and then re-run
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] vsdevcmd.bat [args] for additional details.
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] Where [value] is:
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat]    1 : basic debug logging
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat]    2 : detailed debug logging
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat]    3 : trace level logging. Redirection of output to a file when using this level is recommended.
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat] Example: set VSCMD_DEBUG=3
> &nbsp;&nbsp;&nbsp;&nbsp; [ERROR:VsDevCmd.bat]          vsdevcmd.bat > vsdevcmd.trace.txt 2>&1
> 
> &nbsp;&nbsp;&nbsp;&nbsp; show less
> 
> ---
> 

## Comparison of GHA log

### Before

```
...
Error: [ERROR:winsdk.bat] Windows SDK 10.0.10240.0 : 'C:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\um' not found or was incomplete
Error: [ERROR:VsDevCmd.bat] *** VsDevCmd.bat encountered errors. Environment may be incomplete and/or incorrect. ***
Error: [ERROR:VsDevCmd.bat] In an uninitialized command prompt, please 'set VSCMD_DEBUG=[value]' and then re-run
Error: [ERROR:VsDevCmd.bat] vsdevcmd.bat [args] for additional details.
Error: [ERROR:VsDevCmd.bat] Where [value] is:
Error: [ERROR:VsDevCmd.bat]    1 : basic debug logging
Error: [ERROR:VsDevCmd.bat]    2 : detailed debug logging
Error: [ERROR:VsDevCmd.bat]    3 : trace level logging. Redirection of output to a file when using this level is recommended.
Error: [ERROR:VsDevCmd.bat] Example: set VSCMD_DEBUG=3
Error: [ERROR:VsDevCmd.bat]          vsdevcmd.bat > vsdevcmd.trace.txt 2>&1
Error: Could not setup Developer Command Prompt: invalid parameters
...
```

### After

```
...
Error: Could not setup Developer Command Prompt: invalid parameters
[ERROR:winsdk.bat] Windows SDK 10.0.10240.0 : 'C:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\um' not found or was incomplete
[ERROR:VsDevCmd.bat] *** VsDevCmd.bat encountered errors. Environment may be incomplete and/or incorrect. ***
[ERROR:VsDevCmd.bat] In an uninitialized command prompt, please 'set VSCMD_DEBUG=[value]' and then re-run
[ERROR:VsDevCmd.bat] vsdevcmd.bat [args] for additional details.
[ERROR:VsDevCmd.bat] Where [value] is:
[ERROR:VsDevCmd.bat]    1 : basic debug logging
[ERROR:VsDevCmd.bat]    2 : detailed debug logging
[ERROR:VsDevCmd.bat]    3 : trace level logging. Redirection of output to a file when using this level is recommended.
[ERROR:VsDevCmd.bat] Example: set VSCMD_DEBUG=3
[ERROR:VsDevCmd.bat]          vsdevcmd.bat > vsdevcmd.trace.txt 2>&1
...
```

</details>