### PR TITLE
Add `x86_64` and `x86-64` aliases for `x64`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 
 - `arch` – target architecture
   - native compilation:
-    - `x64` (default) or its synonyms: `amd64`, `win64`
+    - `x64` (default) or its synonyms: `amd64`, `win64`, `x86_64`
     - `x86` or its synonyms: `win32`
   - cross-compilation: `x86_amd64`, `x86_arm`, `x86_arm64`, `amd64_x86`, `amd64_arm`, `amd64_arm64`
 - `sdk` – Windows SDK to use

--- a/index.js
+++ b/index.js
@@ -90,6 +90,8 @@ function main() {
     let arch_aliases = {
         "win32": "x86",
         "win64": "x64",
+        "x86_64": "x64",
+        "x86-64": "x64",
     }
     // Ignore case when matching as that's what humans expect.
     if (arch.toLowerCase() in arch_aliases) {


### PR DESCRIPTION
By a popular request...

References: #39

`x86_64` is the one that was requested, but sure as hell there are people who'd like `x86-64` as well.