### PR TITLE
Update the action to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   vsversion:
     description: The Visual Studio version to use. This can be the version number (e.g. 16.0 for 2019) or the year (e.g. "2019").
 runs:
-  using: node12
+  using: node16
   main: index.js
 branding:
   icon: terminal


### PR DESCRIPTION
Node 12 is deprecated and gives off a warning:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Fixes #59 