### PR TITLE
Have "Release" job test `release/v1` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@release/v1
       - name: Check out source code
         uses: actions/checkout@v2
       - name: Compile and run some C code


### PR DESCRIPTION
Instead of the v1 tag, that is. This makes it possible to push changes to release/v1 branch and get CI test them without actually moving the release tag which effectively publishes the updates to users.