### PR TITLE
Update Checkout v2 -> v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download Internet
         run: npm install
       - name: Run eslint
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: npm install
       - run: npm audit --audit-level=moderate --production
       - run: npm audit --audit-level=critical
@@ -70,7 +70,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download Internet
         run: npm install
       - name: Enable Developer Command Prompt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@release/v1
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Compile and run some C code
         shell: cmd
         run: |
@@ -26,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: npm audit --audit-level=moderate --production
       - run: npm audit --audit-level=critical

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Basic usage for default compilation settings is like this:
 jobs:
   test:
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Build something requiring CL.EXE
         run: |
@@ -41,7 +41,7 @@ jobs:
           - amd64_x86
           - amd64_arm64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
NodeJS 12 was deprecated a while ago and now NodeJS 16 is also being deprecated:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

also update examples in the readme to reflect changes