### PR TITLE
Update NodeJS to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   vsversion:
     description: The Visual Studio version to use. This can be the version number (e.g. 16.0 for 2019) or the year (e.g. "2019").
 runs:
-  using: node16
+  using: node20
   main: index.js
 branding:
   icon: terminal


### PR DESCRIPTION
Github is deprecating NodeJS 16 soon, update Node to 20 to silence warnings for users running this action:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/