### PR TITLE
Update NodeJS to v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   vsversion:
     description: The Visual Studio version to use. This can be the version number (e.g. 16.0 for 2019) or the year (e.g. "2019").
 runs:
-  using: node20
+  using: node24
   main: index.js
 branding:
   icon: terminal


### PR DESCRIPTION
Gitub blog: [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):

> For Actions maintainers: Update your actions to run on Node24 instead of Node20